### PR TITLE
fixes test that was failing because of sendgrid

### DIFF
--- a/config/environment.rb
+++ b/config/environment.rb
@@ -3,7 +3,6 @@ require_relative 'application'
 
 # Initialize the Rails application.
 Rails.application.initialize!
-ActionMailer::Base.delivery_method = :smtp
 ActionMailer::Base.smtp_settings = {
   :user_name => ENV["SENDGRID_USERNAME"],
   :password => ENV["SENDGRID_PASSWORD"],

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -27,7 +27,7 @@ Rails.application.configure do
   end
 
   config.action_mailer.raise_delivery_errors = true
-  config.action_mailer.delivery_method = :test
+  # config.action_mailer.delivery_method = :test
   host = 'localhost:3000' # Don't use this literally; use your local dev host instead
   # Use this on the cloud IDE.
   # config.action_mailer.default_url_options = { host: host, protocol: 'https' }

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -62,6 +62,7 @@ Rails.application.configure do
   # config.active_job.queue_name_prefix = "battleship_web_#{Rails.env}"
   config.action_mailer.perform_caching = false
   config.action_mailer.default_url_options = { :host => "https://polar-refuge-52259.herokuapp.com" }
+  ActionMailer::Base.delivery_method = :smtp
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -26,7 +26,6 @@ Rails.application.configure do
   config.action_dispatch.show_exceptions = false
 
   # Disable request forgery protection in test environment.
-  config.action_mailer.delivery_method = :test
   config.action_mailer.default_url_options = { host: 'localhost:3000' }
 
   config.action_controller.allow_forgery_protection = false

--- a/spec/features/non-activated_user_can_activate_account_spec.rb
+++ b/spec/features/non-activated_user_can_activate_account_spec.rb
@@ -16,7 +16,6 @@ describe 'non-activated user' do
       fill_in :user_password, with: password
       fill_in :user_password_confirmation, with: password
       click_on "Submit"
-
       expect(ActionMailer::Base.deliveries.size).to eq(1)
       user = User.first
       expect(user.activated?).to eq(false)


### PR DESCRIPTION
removes "ActionMailer::Base.delivery_method = :smtp" from config/environment.rb to config/environments/production.rb. 